### PR TITLE
Enable support for VS 2022 ARM64

### DIFF
--- a/src/TrailingWhitespace.csproj
+++ b/src/TrailingWhitespace.csproj
@@ -111,11 +111,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" ExcludeAssets="Runtime">
-      <Version>17.0.0-previews-4-31709-430</Version>
+      <Version>17.10.40171</Version>
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.0.5232</Version>
+      <Version>17.11.414</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -14,6 +14,9 @@
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
+      <ProductArchitecture>arm64</ProductArchitecture>
+    </InstallationTarget>
   </Installation>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
This change adds support for the `arm64` platform architecture by updating the tooling packages to the latest versions and adding a new entry for the `arm64` `ProductArchitecture`.

Note that there are 3 new warnings identified by analyzers after the package upgrades:
```
  \src\Commands\TextviewCreationListener.cs(31,63): warning VSTHRD010: Accessing "DTE2" should onl
y be done on the main thread. Call Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread() first. (https://git
hub.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md) [\src\TrailingWhitespace.cspr
oj]
  \src\Helpers\FileHelpers.cs(49,31): warning VSTHRD010: Accessing "DTE2" should only be done on t
he main thread. Call Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread() first. (https://github.com/Micros
oft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md) [\src\TrailingWhitespace.csproj]
  \src\Helpers\FileHelpers.cs(50,44): warning VSTHRD010: Accessing "DTE2" should only be done on t
he main thread. Call Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread() first. (https://github.com/Micros
oft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md) [\src\TrailingWhitespace.csproj]
```

Fixes https://github.com/madskristensen/TrailingWhitespace/issues/68.