### PR TITLE
Downgrade SDKs to 17.8

### DIFF
--- a/src/TrailingWhitespace.csproj
+++ b/src/TrailingWhitespace.csproj
@@ -111,11 +111,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" ExcludeAssets="Runtime">
-      <Version>17.10.40171</Version>
+      <Version>17.8.37222</Version>
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.11.414</Version>
+      <Version>17.8.2365</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Fixes #70, #71, #72

It appears the supported Visual Studio versions are tied to the SDK versions. Given that [17.8 is the earliest version still getting updates](https://learn.microsoft.com/en-us/lifecycle/products/visual-studio-2022), I decided to downgrade the SDKs to the VS 17.8 equivalent.

I've tested that this change builds and runs on both 17.8 and 17.12.